### PR TITLE
Add the 'aws' CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Builds on the upstream [actions-runner][1] with the following additions:
  1. kubectl
  2. vault
  3. Python for use with [setup-python][2]
+ 4. aws
 
 The primary use case is to deploy to a kubernetes cluster using short lived
 tokens starting from the Github oidc id jwt.

--- a/runner/actions-runner-ois.ubuntu-22.04.dockerfile
+++ b/runner/actions-runner-ois.ubuntu-22.04.dockerfile
@@ -12,6 +12,11 @@ RUN mkdir -p /etc/apt/keyrings \
     && apt-get install -y --no-install-recommends \
     openssh-client \
     kubectl=$KUBE_VERSION-00 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -4 -sL "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip" \
+    && unzip -qq  awscliv2.zip \
+    && ./aws/install -i /usr/local/aws-cli -b /usr/local/bin \
+    && aws --version \
+    && rm -rf awscliv2.zip aws/
 
 USER runner


### PR DESCRIPTION
Problem: The github actions runner used by openinfra doesn't have the `aws` CLI. This means adding an additional install step to all of our GitHub workflows that interact with AWS.

Solution: Install the `aws` CLI onto the runner image we use.

Outcome: The `aws` CLI is available to use for all Openinfra Github Actions workflows that use our self-hosted runners.


Notes:
* This uses an install process similar to how the public, upstream GitHub runners do it: 
https://github.com/actions/runner-images/blob/main/images/linux/scripts/installers/aws.sh
* This has to account for both `X86_64` **and** `aarch64` (ARM) architectures.